### PR TITLE
Fix spherical harmonics expansion

### DIFF
--- a/src/napari_stress/_tests/test_spherical_harmonic_fit.py
+++ b/src/napari_stress/_tests/test_spherical_harmonic_fit.py
@@ -9,16 +9,16 @@ def test_spherical_harmonics():
 
     # Test pyshtools implementation
     points = napari_stress.fit_spherical_harmonics(ellipse.points(), max_degree=3,
-                                                   implementation='shtools')[0]
+                                                   implementation='shtools')
     assert np.array_equal(ellipse.points().shape, points.shape)
 
     # Test stress implementation
     points = napari_stress.fit_spherical_harmonics(ellipse.points(), max_degree=3,
-                                                   implementation='stress')[0]
+                                                   implementation='stress')
     assert np.array_equal(ellipse.points().shape, points.shape)
 
     # Test default implementations
-    points = napari_stress.fit_spherical_harmonics(ellipse.points(), max_degree=3)[0]
+    points = napari_stress.fit_spherical_harmonics(ellipse.points(), max_degree=3)
     assert np.array_equal(ellipse.points().shape, points.shape)
 
 def test_quadrature(make_napari_viewer):

--- a/src/napari_stress/_tests/test_spherical_harmonic_fit.py
+++ b/src/napari_stress/_tests/test_spherical_harmonic_fit.py
@@ -3,7 +3,7 @@ import vedo
 import numpy as np
 import napari_stress
 
-def test_spherical_harmonics():
+def test_spherical_harmonics(make_napari_viewer):
 
     ellipse = vedo.shapes.Ellipsoid()
 
@@ -20,6 +20,9 @@ def test_spherical_harmonics():
     # Test default implementations
     points = napari_stress.fit_spherical_harmonics(ellipse.points(), max_degree=3)
     assert np.array_equal(ellipse.points().shape, points.shape)
+
+    viewer = make_napari_viewer()
+    points = napari_stress.measure_curvature(ellipse.points(), viewer=viewer)
 
 def test_quadrature(make_napari_viewer):
     points = napari_stress.get_droplet_point_cloud()[0]


### PR DESCRIPTION
Closes #82 
Closes #66 

This implements the same fix as in the curvature measurement function. 

In the long run we should think about how we can handle layerdata tuples better. The `frame_by_frame` can handle `LayerDataTuple` and `List[LayerDataTuple]` but they are incompatible with the current workflow implementation.