### PR TITLE
Re-arrange coefficient matrix

### DIFF
--- a/src/napari_stress/_spherical_harmonics/sph_func_SPB.py
+++ b/src/napari_stress/_spherical_harmonics/sph_func_SPB.py
@@ -1,7 +1,7 @@
 # From https://github.com/campaslab/STRESS
 #! We use spherical_harmonics_function to encapsulate data from SPH Basis of functions, regardless of chart
 
-from numpy  import *
+from numpy import *
 import numpy as np
 from scipy  import *
 import mpmath
@@ -288,6 +288,21 @@ def Un_Flatten_Coef_Vec(coefficient_vector, basis_degree):
             row = row + 1
 
     return coefficient_matrix
+
+def convert_coeffcient_matrix_to_pyshtools_format(coefficients: np.ndarray
+                                                  )-> np.ndarray:
+    """
+    Convert a stress-coefficient matrix (deg+1 x deg+1) to pyshtools format.
+
+    The pyshtools format follows a (2, deg+1, deg+1) shape codex, whereas the
+    first dimension refers to the cosine/sine parts of the expansion.
+    """
+    upper = np.triu(coefficients)
+    lower = np.tril(coefficients)
+
+    coefficients = np.stack([upper.transpose(), lower])
+
+    return coefficients
 
 
 # Gives L_1 Integral on SPHERE pullback:

--- a/src/napari_stress/_tests/test_spherical_harmonic_fit.py
+++ b/src/napari_stress/_tests/test_spherical_harmonic_fit.py
@@ -8,14 +8,14 @@ def test_frontend_spherical_harmonics():
     ellipse = vedo.shapes.Ellipsoid()
 
     # Test pyshtools implementation
-    points = napari_stress.fit_spherical_harmonics(ellipse.points(), max_degree=3,
-                                                   implementation='shtools')[0]
-    assert np.array_equal(ellipse.points().shape, points.shape)
+    points1 = napari_stress.fit_spherical_harmonics(ellipse.points(), max_degree=3,
+                                                   implementation='shtools')
+    assert np.array_equal(ellipse.points().shape, points1[0].shape)
 
     # Test stress implementation
-    points = napari_stress.fit_spherical_harmonics(ellipse.points(), max_degree=3,
-                                                   implementation='stress')[0]
-    assert np.array_equal(ellipse.points().shape, points.shape)
+    points2 = napari_stress.fit_spherical_harmonics(ellipse.points(), max_degree=3,
+                                                   implementation='stress')
+    assert np.array_equal(ellipse.points().shape, points2[0].shape)
 
     # Test default implementations
     points = napari_stress.fit_spherical_harmonics(ellipse.points(), max_degree=3)[0]
@@ -34,6 +34,19 @@ def test_spherical_harmonics():
                                                          use_minimal_point_set=False)  # with pickle
     lebedev_points, lebedev_info = sh.lebedev_quadrature(coeffs_stress)  # without pickle
 
+def test_interoperatibility():
+
+    from napari_stress._spherical_harmonics import spherical_harmonics as sh
+    from napari_stress._spherical_harmonics.sph_func_SPB import convert_coeffcient_matrix_to_pyshtools_format
+
+    points = napari_stress.get_droplet_point_cloud()[0][0][:, 1:]
+
+    pts_pysh, coeffs_pysh = sh.shtools_spherical_harmonics_expansion(points, max_degree=5)
+    pts_stress, coeffs_stress = sh.stress_spherical_harmonics_expansion(points, max_degree=5)
+
+    coeffs_converted = convert_coeffcient_matrix_to_pyshtools_format(coeffs_stress[0])
+
+
 def test_quadrature(make_napari_viewer):
     points = napari_stress.get_droplet_point_cloud()[0]
 
@@ -47,4 +60,4 @@ def test_quadrature(make_napari_viewer):
 
 if __name__ == '__main__':
     import napari
-    test_quadrature(napari.Viewer)
+    test_interoperatibility()

--- a/src/napari_stress/_tests/test_spherical_harmonic_fit.py
+++ b/src/napari_stress/_tests/test_spherical_harmonic_fit.py
@@ -60,30 +60,30 @@ def test_interoperatibility():
     _coeffs_stress = np.stack([coeffs_str_x, coeffs_str_y, coeffs_str_z])
     assert all((_coeffs_stress - coeffs_stress).flatten() == 0)
 
-    # Let's check whether these two give the same values when evaluated at the
-    # same coordinates
+    # # Let's check whether these two give the same values when evaluated at the
+    # # same coordinates
 
-    theta = np.linspace(0, 2*np.pi, 50)
-    phi = np.linspace(0, 2*np.pi, 100)
-    THETA, PHI = np.meshgrid(theta, phi)
-    # Stress:
-    SH_stress_x = spherical_harmonics_function(_coeffs_stress[0], SPH_Deg=deg)
-    stress_x = SH_stress_x.Eval_SPH(THETA, PHI)
+    # theta = np.linspace(0, 2*np.pi, 50)
+    # phi = np.linspace(0, 2*np.pi, 100)
+    # THETA, PHI = np.meshgrid(theta, phi)
+    # # Stress:
+    # SH_stress_x = spherical_harmonics_function(_coeffs_stress[0], SPH_Deg=deg)
+    # stress_x = SH_stress_x.Eval_SPH(THETA, PHI)
 
-    SH_stress_y = spherical_harmonics_function(_coeffs_stress[1], SPH_Deg=deg)
-    stress_y = SH_stress_y.Eval_SPH(THETA, PHI)
+    # SH_stress_y = spherical_harmonics_function(_coeffs_stress[1], SPH_Deg=deg)
+    # stress_y = SH_stress_y.Eval_SPH(THETA, PHI)
 
-    SH_stress_z = spherical_harmonics_function(_coeffs_stress[2], SPH_Deg=deg)
-    stress_z = SH_stress_z.Eval_SPH(THETA, PHI)
+    # SH_stress_z = spherical_harmonics_function(_coeffs_stress[2], SPH_Deg=deg)
+    # stress_z = SH_stress_z.Eval_SPH(THETA, PHI)
 
-    stress_pts = np.stack([stress_z.flatten(), stress_y.flatten(), stress_x.flatten()]).transpose()
+    # stress_pts = np.stack([stress_z.flatten(), stress_y.flatten(), stress_x.flatten()]).transpose()
 
 
-    # Pyshtools:
-    pysh_x = coeffs_pysh_x.expand(lon = list(np.rad2deg(THETA.flatten())), lat=list(np.rad2deg(PHI.flatten())))
-    pysh_y = coeffs_pysh_y.expand(lon = list(np.rad2deg(THETA.flatten())), lat=list(np.rad2deg(PHI.flatten())))
-    pysh_z = coeffs_pysh_z.expand(lon = list(np.rad2deg(THETA.flatten())), lat=list(np.rad2deg(PHI.flatten())))
-    pysh_pts = np.stack([pysh_x, pysh_y, pysh_z]).transpose()
+    # # Pyshtools:
+    # pysh_x = coeffs_pysh_x.expand(lon = list(np.rad2deg(THETA.flatten())), lat=list(np.rad2deg(PHI.flatten())))
+    # pysh_y = coeffs_pysh_y.expand(lon = list(np.rad2deg(THETA.flatten())), lat=list(np.rad2deg(PHI.flatten())))
+    # pysh_z = coeffs_pysh_z.expand(lon = list(np.rad2deg(THETA.flatten())), lat=list(np.rad2deg(PHI.flatten())))
+    # pysh_pts = np.stack([pysh_x, pysh_y, pysh_z]).transpose()
 
 
 

--- a/src/napari_stress/_tests/test_spherical_harmonic_fit.py
+++ b/src/napari_stress/_tests/test_spherical_harmonic_fit.py
@@ -38,13 +38,16 @@ def test_interoperatibility():
 
     from napari_stress._spherical_harmonics import spherical_harmonics as sh
     from napari_stress._spherical_harmonics.sph_func_SPB import convert_coeffcient_matrix_to_pyshtools_format
+    from pyshtools import SHCoeffs
 
     points = napari_stress.get_droplet_point_cloud()[0][0][:, 1:]
 
     pts_pysh, coeffs_pysh = sh.shtools_spherical_harmonics_expansion(points, max_degree=5)
     pts_stress, coeffs_stress = sh.stress_spherical_harmonics_expansion(points, max_degree=5)
 
-    coeffs_converted = convert_coeffcient_matrix_to_pyshtools_format(coeffs_stress[0])
+    coeffs_x = SHCoeffs.from_array(convert_coeffcient_matrix_to_pyshtools_format(coeffs_stress[0]))
+    coeffs_y = SHCoeffs.from_array(convert_coeffcient_matrix_to_pyshtools_format(coeffs_stress[1]))
+    coeffs_z = SHCoeffs.from_array(convert_coeffcient_matrix_to_pyshtools_format(coeffs_stress[2]))
 
 
 def test_quadrature(make_napari_viewer):

--- a/src/napari_stress/_tests/test_spherical_harmonic_fit.py
+++ b/src/napari_stress/_tests/test_spherical_harmonic_fit.py
@@ -37,7 +37,8 @@ def test_spherical_harmonics():
 def test_interoperatibility():
 
     from napari_stress._spherical_harmonics import spherical_harmonics as sh
-    from napari_stress._spherical_harmonics.sph_func_SPB import convert_coeffcient_matrix_to_pyshtools_format
+    from napari_stress._spherical_harmonics.sph_func_SPB import convert_coeffcients_stress_to_pyshtools,\
+        convert_coefficients_pyshtools_to_stress
     from pyshtools import SHCoeffs
 
     points = napari_stress.get_droplet_point_cloud()[0][0][:, 1:]
@@ -45,10 +46,13 @@ def test_interoperatibility():
     pts_pysh, coeffs_pysh = sh.shtools_spherical_harmonics_expansion(points, max_degree=5)
     pts_stress, coeffs_stress = sh.stress_spherical_harmonics_expansion(points, max_degree=5)
 
-    coeffs_x = SHCoeffs.from_array(convert_coeffcient_matrix_to_pyshtools_format(coeffs_stress[0]))
-    coeffs_y = SHCoeffs.from_array(convert_coeffcient_matrix_to_pyshtools_format(coeffs_stress[1]))
-    coeffs_z = SHCoeffs.from_array(convert_coeffcient_matrix_to_pyshtools_format(coeffs_stress[2]))
-
+    coeffs_pysh_x = convert_coeffcients_stress_to_pyshtools(coeffs_stress[0])
+    coeffs_pysh_y = convert_coeffcients_stress_to_pyshtools(coeffs_stress[1])
+    coeffs_pysh_z = convert_coeffcients_stress_to_pyshtools(coeffs_stress[2])
+    
+    coeffs_str_x = convert_coefficients_pyshtools_to_stress(coeffs_pysh_x)
+    coeffs_str_y = convert_coefficients_pyshtools_to_stress(coeffs_pysh_y)
+    coeffs_str_z = convert_coefficients_pyshtools_to_stress(coeffs_pysh_z)
 
 def test_quadrature(make_napari_viewer):
     points = napari_stress.get_droplet_point_cloud()[0]


### PR DESCRIPTION
This PR adds conversion functions that can convert a set of spherical harmonics coefficients from stress formatting to pyshtools formatting and back.


Example for degree = 5:
pyshtools format: `2x6x6` - `coefficients[0]` denote the real/cosine part, `coefficients[1]` refers to the imaginary/sine part
stress format: `6x6`: lower triangular section of the matrix is imaginary/sine part, upper triangular section is real/cosine part.

The tests assert that converting coefficients from one to another does not change the coefficient's values.

To be resolved: It would be nice if it wouldn't make a difference which implementation (stress or pyshtools) was used to evaluate the spherical harmonics function - unfortunately this is still the case. Still, as the coefficients are the same, there is some degree of interoperability.

See also #86 