### PR TITLE
fix euler number usage

### DIFF
--- a/src/napari_stress/_stress/charts_SPB.py
+++ b/src/napari_stress/_stress/charts_SPB.py
@@ -1,6 +1,7 @@
 # From https://github.com/campaslab/STRESS
 #from numpy  import *
 import numpy as np
+import math
 from scipy  import *
 import mpmath
 import cmath
@@ -50,7 +51,7 @@ def Domain_Unaffected(Theta, Phi): #Where fns in each chart arent affected by et
 
 def Bump_Fn(Eval_Pt, Max_Val, Start, Length): #can be evaluated on [start, start+Length)
 	X_2 = ((Eval_Pt-Start)/Length)**2
-	return (Max_Val*e)*e**(-1/(1-X_2))
+	return (Max_Val * math.e) * np.exp(-1/(1-X_2))
 	# B(E) = Me*e^(-1/(1-((E-S)/L)^2))
 
 	###!! Linear Cutoff !!###


### PR DESCRIPTION
The starred import of `scipy` and subsequent error of `e` instead of `scipy.e` or `math.e` threw an error in the github CI. This fixes the error.