### PR TITLE
add napari-matplotlib to dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ install_requires =
     napari_segment_blobs_and_things_with_membranes
     mpmath
     pyshtools
+    napari-matplotlib
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Pull request to a pull request! :) This adds napari-matplotlib to the dependencies of napari-stress, tests should pass then.