### PR TITLE
Move trace refinment

### DIFF
--- a/src/napari_stress/__init__.py
+++ b/src/napari_stress/__init__.py
@@ -2,8 +2,8 @@ __version__ = "0.0.21"
 
 from . import _measurements as measurements
 from . import _approximation as approximation
+from . import _reconstruction as reconstruction
 
-from ._refine_surfaces import trace_refinement_of_surface
 from ._preprocess import rescale
 from ._surface import adjust_surface_density,\
     smooth_sinc,\

--- a/src/napari_stress/_reconstruction/__init__.py
+++ b/src/napari_stress/_reconstruction/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from .refine_surfaces import trace_refinement_of_surface

--- a/src/napari_stress/_reconstruction/refine_surfaces.py
+++ b/src/napari_stress/_reconstruction/refine_surfaces.py
@@ -3,8 +3,8 @@
 import vedo
 from napari.types import SurfaceData, ImageData, PointsData
 
-from ._utils.fit_utils import _sigmoid, _gaussian, _function_args_to_list, _detect_max_gradient, _detect_maxima
-from ._utils.frame_by_frame import frame_by_frame
+from .._utils.fit_utils import _sigmoid, _gaussian, _function_args_to_list, _detect_max_gradient, _detect_maxima
+from .._utils.frame_by_frame import frame_by_frame
 
 from scipy.interpolate import RegularGridInterpolator
 from scipy.optimize import curve_fit

--- a/src/napari_stress/_tests/test_surface_refinement.py
+++ b/src/napari_stress/_tests/test_surface_refinement.py
@@ -2,7 +2,7 @@
 import numpy as np
 
 def test_surface_tracing(make_napari_viewer):
-    from napari_stress import trace_refinement_of_surface
+    from napari_stress import reconstruction
     from skimage import filters, morphology, io, measure
     from vedo import shapes
 
@@ -21,7 +21,7 @@ def test_surface_tracing(make_napari_viewer):
 
     # Test different fit methods (fancy/quick)
     fit_type = 'quick'
-    traced_points = trace_refinement_of_surface(blurry_sphere, surf_points,
+    traced_points = reconstruction.trace_refinement_of_surface(blurry_sphere, surf_points,
                                                 trace_length=20,
                                                 sampling_distance=1.0,
                                                 selected_fit_type=fit_type,
@@ -32,7 +32,7 @@ def test_surface_tracing(make_napari_viewer):
     assert np.allclose(true_radius, mean_radii, atol=1)
 
     fit_type = 'fancy'
-    traced_points = trace_refinement_of_surface(blurry_sphere, surf_points,
+    traced_points = reconstruction.trace_refinement_of_surface(blurry_sphere, surf_points,
                                                 trace_length=10,
                                                 selected_fit_type=fit_type,
                                                 remove_outliers=False)
@@ -43,7 +43,7 @@ def test_surface_tracing(make_napari_viewer):
 
     # Test outlier identification
     surf_points[0] += [0, 0, 10]
-    traced_points = trace_refinement_of_surface(blurry_sphere, surf_points,
+    traced_points = reconstruction.trace_refinement_of_surface(blurry_sphere, surf_points,
                                                 trace_length=10,
                                                 selected_fit_type=fit_type,
                                                 remove_outliers=True)
@@ -56,7 +56,7 @@ def test_surface_tracing(make_napari_viewer):
     surf_points += (surf_points * true_radius + 2) + 50
 
     fit_type = 'fancy'
-    traced_points = trace_refinement_of_surface(blurry_ring, surf_points,
+    traced_points = reconstruction.trace_refinement_of_surface(blurry_ring, surf_points,
                                                 trace_length=10,
                                                 sampling_distance=0.1,
                                                 selected_fit_type=fit_type,
@@ -64,7 +64,7 @@ def test_surface_tracing(make_napari_viewer):
                                                 remove_outliers=False)
 
     fit_type = 'quick'
-    traced_points = trace_refinement_of_surface(blurry_ring, surf_points,
+    traced_points = reconstruction.trace_refinement_of_surface(blurry_ring, surf_points,
                                                 trace_length=10,
                                                 sampling_distance=0.1,
                                                 selected_fit_type=fit_type,

--- a/src/napari_stress/napari.yaml
+++ b/src/napari_stress/napari.yaml
@@ -6,8 +6,9 @@ contributions:
       python_name: napari_stress._preprocess:rescale
       title: Rescale image data by given scale factors
 
+    # Reconstruction
     - id: napari-stress.trace_refine_surface
-      python_name: napari_stress._refine_surfaces:trace_refinement_of_surface
+      python_name: napari_stress.reconstruction:trace_refinement_of_surface
       title: Fit point location on a surface according to a given intensity image
     - id: napari-stress.reconstruct_surface
       python_name: napari_stress._surface:reconstruct_surface


### PR DESCRIPTION
This moves the `trace_refinement_of_surface` to the new submodule `reconstruction`.

Closes #165 