### PR TITLE
remove napari pin and npe2 support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,8 +39,8 @@ include_package_data = True
 install_requires =
     numpy
     vedo
-    napari<=0.4.15
-    vispy<=0.9.6
+    napari
+    vispy
     matplotlib
     tqdm
     scipy
@@ -62,7 +62,5 @@ napari-stress =
     napari.yaml
 
 [options.entry_points]
-napari.manifest =
-    napari-stress = napari_stress:napari.yaml
 napari.plugin =
-    napari-stress2 = napari_stress._napari_plugin
+    napari-stress = napari_stress._napari_plugin


### PR DESCRIPTION
Hi Johannes @jo-mueller ,

this PR should make it possible to run napari-stress in napari > 0.4.15 AND have its menu entries in the tools menu. I've tested this in an empty conda environment like this:

```
mamba create --name napari_only python=3.9 napari=0.4.16 -c conda-forge
conda activate napari_only
cd napari-stress
pip install -e .
```

Afterwards, napari-stress shows up in the tools menu, but not in the plugins menu. If we want to have it in the plugins-menu as well, we would need to implement something like this to be fully npe1 compatible.
* https://github.com/BiAPoL/napari-clusters-plotter/blob/main/napari_clusters_plotter/_dock_widget.py#L9-L16

I would not do it. I think its enough to have it in the Tools menu only.

Let me know what you think!

Best,
Robert
