### PR TITLE
pin vedo version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ include_package_data = True
 # add your package requirements here
 install_requires =
     numpy
-    vedo
+    vedo==2022.3.0
     napari
     vispy
     matplotlib


### PR DESCRIPTION
#173 

This pins the vedo version to 2022.3.0, for which tests pass. 