### PR TITLE
prevent executing demo notebooks in github CI

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,7 +3,7 @@ title: Napari-stress documentation
 author: Johannes Müller
 logo: logo.png
 execute:
-  execute_notebooks: force
+  execute_notebooks: off
 
 # Add a bibtex file so that we can create citations
 bibtex_bibfiles:


### PR DESCRIPTION
Hi Johannes @jo-mueller ,

I just had a look in the new jupyter-book based documentation. Super cool style! Just one thing, many notebooks show this error message: `ModuleNotFoundError: No module named 'napari_stress'`, e.g. here: https://biapol.github.io/napari-stress/02_toolboxes/03_analyze_everything/demo_analyze_everything.html

I presume this PR fixes this. If you don't see any issue with this, let's try it out :-) 

Thanks!

Best,
Robert
